### PR TITLE
Deprecated CalendarEventDevice

### DIFF
--- a/exchange-calendar/calendar.py
+++ b/exchange-calendar/calendar.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from homeassistant.components.calendar import (
     ENTITY_ID_FORMAT,
     PLATFORM_SCHEMA,
-    CalendarEventDevice,
+    CalendarEntity,
     get_date,
     is_offset_reached,
 )
@@ -80,7 +80,7 @@ def setup_platform(hass, config, add_entities, disc_info=None):
     add_entities(calendar_devices, True)
 
 
-class ExchangeCalendarEventDevice(CalendarEventDevice):
+class ExchangeCalendarEventDevice(CalendarEntity):
     """A device for getting the next Task from a Exchange Calendar."""
 
     def __init__(self, name, calendar, entity_id, all_day=False, search=None):

--- a/exchange-calendar/manifest.json
+++ b/exchange-calendar/manifest.json
@@ -3,6 +3,7 @@
     "name": "Exchange Calendar",
     "documentation": "https://github.com/maxlaverse/home-assistant-exchange-calendar",
     "dependencies": [],
+    "requirements": ["exchangelib==3.3.2"],
     "codeowners": [],
     "iot_class": "local_polling",
     "version": "0.1.0"


### PR DESCRIPTION
Changed to CalendarEntity

Also added req. in manifest for Hassio to auto load dependency exchangelib.
Ended up not working non the less due to our Exchange 2010 being outdated and throwing an "The SMTP address has no mailbox associated with it" error, but these should still be required for any newer Hassio version.

Exchangelib can be increased to 4.9.0 if wanted.